### PR TITLE
Add "Don't share machine with others"

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,7 @@
             <h3>Don't</h3>
             <ul>
                 <li>enroll anything other than NAV owned devices.</li>
+                <li>share your device with others. A naisdevice is a personal device.</li>
                 <li>turn on sshd or similar services on your device.</li>
                 <li>set up your device as a proxy. For anything!</li>
                 <li>share network interfaces with virtual machines, meaning set them up as seperate nodes on the network.</li>


### PR DESCRIPTION
Added an explicit "Don't". A naisdevice is personal and the primary user is the only user. This will trigger re-approval by all users. A merge now might be good timing as "everyone" will have expired tokens next time they attempt logon.

However. There might be compelling reasons for allowing this. 